### PR TITLE
refactor: tidy interface

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/build.config.ts
+++ b/build.config.ts
@@ -3,11 +3,7 @@ import { defineBuildConfig } from "unbuild";
 export default defineBuildConfig({
   clean: true,
   declaration: true,
-  entries: [
-    "src/index.ts",
-    "src/server-specification/index.ts",
-    "src/storage/index.ts",
-  ],
+  entries: ["src/index.ts"],
   outDir: "dist",
   rollup: {
     esbuild: {

--- a/examples/simple-api/src/spec.ts
+++ b/examples/simple-api/src/spec.ts
@@ -13,7 +13,7 @@ export const simpleSpecification: IdempotentRequestServerSpecification = {
   getStorageKey: ({ idempotencyKey, request }) => {
     const path = new URL(request.url).pathname;
 
-    return `${path}-${idempotencyKey}`;
+    return `${request.method}-${path}-${idempotencyKey}`;
   },
 
   satisfiesKeySpec(idempotencyKey) {

--- a/examples/simple-api/src/spec.ts
+++ b/examples/simple-api/src/spec.ts
@@ -1,27 +1,23 @@
-import type { IdempotentRequestServerSpecification } from "hono-idempotent-request/server-specification";
+import type { IdempotentRequestServerSpecification } from "hono-idempotent-request";
 
 import { sha256 } from "@oslojs/crypto/sha2";
 import { encodeHexLowerCase } from "@oslojs/encoding";
-import {
-  createIdempotencyFingerprint,
-  createIdempotentStorageKey,
-} from "hono-idempotent-request";
 import * as v from "valibot";
 
 export const simpleSpecification: IdempotentRequestServerSpecification = {
   getFingerprint: async (request) => {
     const body = await request.text();
-    return createIdempotencyFingerprint(hashWithSha256(body));
+    return hashWithSha256(body);
   },
-  getStorageKey: (request) => {
-    const path = new URL(request.url).pathname;
-    const key = request.headers.get("Idempotency-Key");
 
-    return createIdempotentStorageKey(`${path}-${key}`);
+  getStorageKey: ({ idempotencyKey, request }) => {
+    const path = new URL(request.url).pathname;
+
+    return `${path}-${idempotencyKey}`;
   },
-  satisfiesKeySpec: (key) => {
-    // require uuid
-    return v.safeParse(v.pipe(v.string(), v.uuid()), key).success;
+
+  satisfiesKeySpec(idempotencyKey) {
+    return v.safeParse(v.pipe(v.string(), v.uuid()), idempotencyKey).success;
   },
 };
 

--- a/examples/simple-api/src/storage.ts
+++ b/examples/simple-api/src/storage.ts
@@ -1,4 +1,7 @@
-import type { IdempotentRequestStorageDriver } from "hono-idempotent-request";
+import type {
+  IdempotentRequest,
+  IdempotentRequestStorageDriver,
+} from "hono-idempotent-request";
 
 const getExpirationEpoch = (ttlSeconds: number) => {
   const nowEpoch = Date.now() / 1000;
@@ -13,10 +16,10 @@ export const createCloudflareKVStorageDriver = (
 
   return {
     async get(storageKey) {
-      return kv.get(storageKey, "json");
+      return await kv.get<IdempotentRequest>(storageKey, "json");
     },
     async save(request) {
-      return kv.put(request.storageKey, JSON.stringify(request), {
+      await kv.put(request.storageKey, JSON.stringify(request), {
         expiration: sunset,
       });
     },

--- a/integration-tests/hono/src/server-specification.ts
+++ b/integration-tests/hono/src/server-specification.ts
@@ -1,15 +1,7 @@
-import type {
-  IdempotencyFingerprint,
-  IdempotentStorageKey,
-} from "hono-idempotent-request";
-import type { IdempotentRequestServerSpecification } from "hono-idempotent-request/server-specification";
+import type { IdempotentRequestServerSpecification } from "hono-idempotent-request";
 
 import { sha256 } from "@oslojs/crypto/sha2";
 import { encodeHexLowerCase } from "@oslojs/encoding";
-import {
-  createIdempotencyFingerprint,
-  createIdempotentStorageKey,
-} from "hono-idempotent-request";
 import { version as uuidVersion } from "uuid";
 
 /**
@@ -23,20 +15,17 @@ import { version as uuidVersion } from "uuid";
 export const createTestServerSpecification =
   (): IdempotentRequestServerSpecification => {
     return {
-      getStorageKey(request: Request): IdempotentStorageKey {
+      getStorageKey({ idempotencyKey, request }) {
         const path = new URL(request.url).pathname;
-        const idempotencyKey = request.headers.get("Idempotency-Key");
 
-        return createIdempotentStorageKey(
-          `${request.method}-${path}-${idempotencyKey}`,
-        );
+        return `${request.method}-${path}-${idempotencyKey}`;
       },
 
-      async getFingerprint(request: Request): Promise<IdempotencyFingerprint> {
-        return createIdempotencyFingerprint(await generateHash(request));
+      async getFingerprint(request) {
+        return await generateHash(request);
       },
 
-      satisfiesKeySpec(idempotencyKey: string): boolean {
+      satisfiesKeySpec(idempotencyKey) {
         try {
           return uuidVersion(idempotencyKey) === 4;
         } catch {

--- a/integration-tests/hono/tests/index.test.ts
+++ b/integration-tests/hono/tests/index.test.ts
@@ -1,11 +1,12 @@
-import type { IdempotentRequestServerSpecification } from "hono-idempotent-request/server-specification";
-import type { IdempotentRequestStorage } from "hono-idempotent-request/storage";
+import type {
+  IdempotentRequestServerSpecification,
+  IdempotentRequestStorageDriver,
+} from "hono-idempotent-request";
 
 import { sValidator } from "@hono/standard-validator";
 import { createMiddleware } from "@universal-middleware/hono";
 import { Hono } from "hono";
 import {
-  createIdempotentStorageKey,
   IdempotencyKeyStorageError,
   idempotentRequestUniversalMiddleware,
   UnsafeImplementationError,
@@ -15,7 +16,7 @@ import { v4 as uuidv4 } from "uuid";
 import * as v from "valibot";
 import { describe, expect, it, vi } from "vitest";
 
-import { createInMemoryIdempotentRequestCacheStorage } from "../src/in-memory-storage";
+import { createInMemoryDriver } from "../src/in-memory-storage";
 import { createTestServerSpecification } from "../src/server-specification";
 
 /**
@@ -68,12 +69,12 @@ const racer = createRacer({
 });
 
 type SetupAppArgs = {
+  driver: IdempotentRequestStorageDriver;
   specification: IdempotentRequestServerSpecification;
-  storage: IdempotentRequestStorage;
 };
 
-const setupApp = ({ specification, storage }: Partial<SetupAppArgs> = {}) => {
-  storage ??= createInMemoryIdempotentRequestCacheStorage();
+const setupApp = ({ driver, specification }: Partial<SetupAppArgs> = {}) => {
+  driver ??= createInMemoryDriver();
   specification ??= createTestServerSpecification();
 
   type HonoEnv = {
@@ -103,8 +104,12 @@ const setupApp = ({ specification, storage }: Partial<SetupAppArgs> = {}) => {
       idempotentRequest({
         // explicitly set to always to make tests simpler
         activationStrategy: "always",
-        specification,
-        storage,
+        server: {
+          specification,
+        },
+        storage: {
+          driver,
+        },
       }),
     )
     .post(
@@ -128,7 +133,7 @@ const setupApp = ({ specification, storage }: Partial<SetupAppArgs> = {}) => {
       },
     );
 
-  return { app, setHonoEnv, specification, storage };
+  return { app, driver, setHonoEnv, specification };
 };
 
 describe("idempotentRequest middleware", () => {
@@ -157,9 +162,9 @@ describe("idempotentRequest middleware", () => {
     });
 
     it("should return cached response on subsequent requests with same Idempotency-Key", async () => {
-      const { app, setHonoEnv, storage } = setupApp();
+      const { app, driver, setHonoEnv } = setupApp();
       const idempotencyKey = uuidv4();
-      const createOrFindSpy = vi.spyOn(storage, "findOrCreate");
+      const driverSpy = vi.spyOn(driver, "get");
       const createRequest = () => {
         return new Request("http://127.0.0.1:3000/api/hello", {
           body: JSON.stringify({ name: "Edison" }),
@@ -177,9 +182,6 @@ describe("idempotentRequest middleware", () => {
         setHonoEnv(),
       );
 
-      // ensure cache storage is updated
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
       const cachedResponse = await app.request(
         createRequest(),
         undefined,
@@ -187,16 +189,14 @@ describe("idempotentRequest middleware", () => {
       );
 
       // 2nd request should hit cached, non-locked response
-      expect(createOrFindSpy).toHaveLastReturnedWith({
-        created: false,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        storedRequest: expect.objectContaining({
+      expect(driverSpy).toHaveLastReturnedWith(
+        expect.objectContaining({
           idempotencyKey,
           lockedAt: null,
           requestMethod: "POST",
           requestPath: "/api/hello",
         }),
-      });
+      );
       expect(response.status).toEqual(cachedResponse.status);
       expect(await response.json()).toStrictEqual(await cachedResponse.json());
     });
@@ -231,8 +231,7 @@ describe("idempotentRequest middleware", () => {
     });
 
     it("should return 400 if Idempotency-Key does not satisfy the server specification", async () => {
-      const { app, setHonoEnv, storage } = setupApp();
-      const createSpy = vi.spyOn(storage, "findOrCreate");
+      const { app, setHonoEnv } = setupApp();
 
       const response = await app.request(
         "/api/hello",
@@ -249,7 +248,6 @@ describe("idempotentRequest middleware", () => {
         setHonoEnv(),
       );
 
-      expect(createSpy).not.toHaveBeenCalled();
       expect(response.status).toBe(400);
       expect(await response.json()).toStrictEqual({
         detail:
@@ -341,13 +339,13 @@ describe("idempotentRequest middleware", () => {
 
   describe("Error handling", () => {
     it("should store the error response in the cache storage", async () => {
-      const { app, setHonoEnv, storage } = setupApp();
+      const { app, driver, setHonoEnv } = setupApp();
       app.post("/api/trigger-error", () => {
         throw new HTTPException(500, {
           message: "Only for testing",
         });
       });
-      const setResponseAndUnlockSpy = vi.spyOn(storage, "setResponseAndUnlock");
+      const saveSpy = vi.spyOn(driver, "save");
       const idempotencyKey = uuidv4();
 
       const response = await app.request(
@@ -361,23 +359,27 @@ describe("idempotentRequest middleware", () => {
         setHonoEnv(),
       );
 
-      expect(setResponseAndUnlockSpy).toHaveBeenCalledWith(
+      expect(saveSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
           idempotencyKey,
           requestMethod: "POST",
           requestPath: "/api/trigger-error",
-        }),
-        expect.objectContaining({
-          body: "Only for testing",
-          status: 500,
+          response: {
+            body: "Only for testing",
+            headers: {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              "content-type": expect.any(String),
+            },
+            status: 500,
+          },
         }),
       );
       expect(response.status).toBe(500);
       expect(await response.text()).toBe("Only for testing");
     });
 
-    it("should wrap errors from cache storage when findOrCreate fails", async () => {
-      const { app, setHonoEnv, storage } = setupApp();
+    it("should wrap errors from cache storage when storage.get fails", async () => {
+      const { app, driver, setHonoEnv } = setupApp();
       app.onError((e, c) => {
         if (e instanceof IdempotencyKeyStorageError) {
           if (e.cause instanceof Error) {
@@ -401,7 +403,7 @@ describe("idempotentRequest middleware", () => {
 
         return c.text("Internal Server Error", 500);
       });
-      vi.spyOn(storage, "findOrCreate").mockImplementation(() => {
+      vi.spyOn(driver, "get").mockImplementation(() => {
         throw new Error("Connection error");
       });
 
@@ -418,15 +420,16 @@ describe("idempotentRequest middleware", () => {
       );
 
       expect(response.status).toBe(500);
-      expect(await response.json()).toStrictEqual({
-        cause: "Connection error",
-        detail: "Failed to find or create the stored idempotent request",
-        title: "Storage Error",
-      });
+      expect(await response.json()).toStrictEqual(
+        expect.objectContaining({
+          cause: "Connection error",
+          title: "Storage Error",
+        }),
+      );
     });
 
-    it("should wrap errors from cache storage when lock fails", async () => {
-      const { app, setHonoEnv, storage } = setupApp();
+    it("should wrap errors from cache storage when storage.save fails", async () => {
+      const { app, driver, setHonoEnv } = setupApp();
       app.onError((e, c) => {
         if (e instanceof IdempotencyKeyStorageError) {
           if (e.cause instanceof Error) {
@@ -450,7 +453,7 @@ describe("idempotentRequest middleware", () => {
 
         return c.text("Internal Server Error", 500);
       });
-      vi.spyOn(storage, "lock").mockImplementation(() => {
+      vi.spyOn(driver, "save").mockImplementation(() => {
         throw new Error("Connection error");
       });
 
@@ -467,61 +470,12 @@ describe("idempotentRequest middleware", () => {
       );
 
       expect(response.status).toBe(500);
-      expect(await response.json()).toStrictEqual({
-        cause: "Connection error",
-        detail: "Failed to lock the stored idempotent request",
-        title: "Storage Error",
-      });
-    });
-
-    it("should wrap errors from cache storage when setResponseAndUnlock fails", async () => {
-      const { app, setHonoEnv, storage } = setupApp();
-      app.onError((e, c) => {
-        if (e instanceof IdempotencyKeyStorageError) {
-          if (e.cause instanceof Error) {
-            return c.json(
-              {
-                cause: e.cause.message,
-                detail: e.message,
-                title: "Storage Error",
-              },
-              500,
-            );
-          }
-          return c.json(
-            {
-              detail: e.message,
-              title: "Storage Error",
-            },
-            500,
-          );
-        }
-
-        return c.text("Internal Server Error", 500);
-      });
-      vi.spyOn(storage, "setResponseAndUnlock").mockImplementation(() => {
-        throw new Error("Connection error");
-      });
-
-      const response = await app.request(
-        "/api/hello",
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "Idempotency-Key": uuidv4(),
-          },
-          method: "POST",
-        },
-        setHonoEnv(),
+      expect(await response.json()).toStrictEqual(
+        expect.objectContaining({
+          cause: "Connection error",
+          title: "Storage Error",
+        }),
       );
-
-      expect(response.status).toBe(500);
-      expect(await response.json()).toStrictEqual({
-        cause: "Connection error",
-        detail:
-          "Failed to save the response of an idempotent request. You should unlock the request manually.",
-        title: "Storage Error",
-      });
     });
   });
 
@@ -530,10 +484,10 @@ describe("idempotentRequest middleware", () => {
       const { app, setHonoEnv } = setupApp({
         specification: {
           getFingerprint: () => null,
-          getStorageKey: (req) => {
-            const path = new URL(req.url).pathname;
-            const method = req.method;
-            return createIdempotentStorageKey(`${method}-${path}`);
+          getStorageKey: ({ request }) => {
+            const path = new URL(request.url).pathname;
+            const method = request.method;
+            return `${method}-${path}`;
           },
           satisfiesKeySpec: () => true,
         },

--- a/integration-tests/hono/tests/index.test.ts
+++ b/integration-tests/hono/tests/index.test.ts
@@ -73,6 +73,10 @@ type SetupAppArgs = {
   specification: IdempotentRequestServerSpecification;
 };
 
+const idempotentRequestMiddleware = createMiddleware(
+  idempotentRequestUniversalMiddleware,
+);
+
 const setupApp = ({ driver, specification }: Partial<SetupAppArgs> = {}) => {
   driver ??= createInMemoryDriver();
   specification ??= createTestServerSpecification();
@@ -93,15 +97,11 @@ const setupApp = ({ driver, specification }: Partial<SetupAppArgs> = {}) => {
     };
   };
 
-  const idempotentRequest = createMiddleware(
-    idempotentRequestUniversalMiddleware,
-  );
-
   const app = new Hono<HonoEnv>()
     .on(
       ["POST", "PUT", "PATCH", "DELETE"],
       "/api/*",
-      idempotentRequest({
+      idempotentRequestMiddleware({
         // explicitly set to always to make tests simpler
         activationStrategy: "always",
         server: {

--- a/integration-tests/hono/tests/index.test.ts
+++ b/integration-tests/hono/tests/index.test.ts
@@ -14,7 +14,7 @@ import {
 import { HTTPException } from "hono/http-exception";
 import { v4 as uuidv4 } from "uuid";
 import * as v from "valibot";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createInMemoryDriver } from "../src/in-memory-storage";
 import { createTestServerSpecification } from "../src/server-specification";
@@ -137,6 +137,10 @@ const setupApp = ({ driver, specification }: Partial<SetupAppArgs> = {}) => {
 };
 
 describe("idempotentRequest middleware", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
   describe("Happy path", () => {
     it("should process request successfully with valid Idempotency-Key", async () => {
       const { app, setHonoEnv } = setupApp();

--- a/package.json
+++ b/package.json
@@ -18,14 +18,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.mjs"
-    },
-    "./server-specification": {
-      "types": "./dist/server-specification/index.d.ts",
-      "default": "./dist/server-specification/index.mjs"
-    },
-    "./storage": {
-      "types": "./dist/storage/index.d.ts",
-      "default": "./dist/storage/index.mjs"
     }
   },
   "keywords": [

--- a/src/brand/index.ts
+++ b/src/brand/index.ts
@@ -14,14 +14,14 @@ export function createIdempotencyFingerprint(
   return p as IdempotencyFingerprint;
 }
 
-// Idempotent Storage Key
+// Storage Key
 
-const IdempotentStorageKeyBrand = Symbol();
+const StorageKeyBrand = Symbol();
 
-export type IdempotentStorageKey = string & {
-  [IdempotentStorageKeyBrand]: unknown;
+export type StorageKey = string & {
+  [StorageKeyBrand]: unknown;
 };
 
-export function createIdempotentStorageKey(p: string): IdempotentStorageKey {
-  return p as IdempotentStorageKey;
+export function createStorageKey(p: string): StorageKey {
+  return p as StorageKey;
 }

--- a/src/idempotent-request.ts
+++ b/src/idempotent-request.ts
@@ -1,0 +1,58 @@
+import type { StorageKey } from "./brand";
+import type { RequestIdentifier } from "./identifier";
+import type { SerializedResponse } from "./serializer";
+
+export type IdempotentRequestBase = Readonly<
+  RequestIdentifier & {
+    /**
+     * Storage key
+     *
+     * This is used to retrieve the request from the storage.
+     */
+    storageKey: StorageKey;
+  }
+>;
+
+export type IdempotentRequest =
+  | ProcessedIdempotentRequest
+  | ProcessingIdempotentRequest
+  | UnProcessedIdempotentRequest;
+
+export type UnProcessedIdempotentRequest = IdempotentRequestBase &
+  Readonly<{
+    /**
+     * Time when the request was locked for processing
+     *
+     * This is used to prevent race conditions when multiple requests are
+     * trying to process the same request concurrently.
+     */
+    lockedAt: null;
+
+    response: null;
+  }>;
+
+export type ProcessingIdempotentRequest = IdempotentRequestBase &
+  Readonly<{
+    /**
+     * Time when the request was locked for processing
+     *
+     * This is used to prevent race conditions when multiple requests are
+     * trying to process the same request concurrently.
+     */
+    lockedAt: Date;
+
+    response: null;
+  }>;
+
+export type ProcessedIdempotentRequest = IdempotentRequestBase &
+  Readonly<{
+    /**
+     * Time when the request was locked for processing
+     *
+     * This is used to prevent race conditions when multiple requests are
+     * trying to process the same request concurrently.
+     */
+    lockedAt: null;
+
+    response: SerializedResponse;
+  }>;

--- a/src/identifier.test.ts
+++ b/src/identifier.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { RequestIdentifier } from "./identifier";
+
+import { createIdempotencyFingerprint } from "./brand";
+import { isIdenticalRequest } from "./identifier";
+
+describe("isIdenticalRequest", () => {
+  const base: RequestIdentifier = {
+    fingerprint: createIdempotencyFingerprint("fp1"),
+    idempotencyKey: "key1",
+    requestMethod: "GET",
+    requestPath: "/api/test",
+  };
+
+  it("returns true for identical requests", () => {
+    const candidate: RequestIdentifier = { ...base };
+    expect(isIdenticalRequest(base, candidate)).toBe(true);
+  });
+
+  it("returns false when request method differs", () => {
+    const candidate: RequestIdentifier = { ...base, requestMethod: "POST" };
+    expect(isIdenticalRequest(base, candidate)).toBe(false);
+  });
+
+  it("returns false when request path differs", () => {
+    const candidate: RequestIdentifier = { ...base, requestPath: "/api/other" };
+    expect(isIdenticalRequest(base, candidate)).toBe(false);
+  });
+
+  it("returns false when idempotencyKey differs", () => {
+    const candidate: RequestIdentifier = { ...base, idempotencyKey: "key2" };
+    expect(isIdenticalRequest(base, candidate)).toBe(false);
+  });
+
+  it("returns false when fingerprint differs", () => {
+    const candidate: RequestIdentifier = {
+      ...base,
+      fingerprint: createIdempotencyFingerprint("fp2"),
+    };
+    expect(isIdenticalRequest(base, candidate)).toBe(false);
+  });
+
+  it("returns true when both fingerprints are null", () => {
+    const target: RequestIdentifier = { ...base, fingerprint: null };
+    const candidate: RequestIdentifier = { ...base, fingerprint: null };
+    expect(isIdenticalRequest(target, candidate)).toBe(true);
+  });
+
+  it("returns false when one fingerprint is null and the other is not", () => {
+    const target: RequestIdentifier = { ...base, fingerprint: null };
+    const candidate: RequestIdentifier = {
+      ...base,
+      fingerprint: createIdempotencyFingerprint("fp1"),
+    };
+    expect(isIdenticalRequest(target, candidate)).toBe(false);
+  });
+});

--- a/src/identifier.ts
+++ b/src/identifier.ts
@@ -1,5 +1,4 @@
-import type { IdempotentRequestServerSpecification } from "./server-specification";
-import type { IdempotencyFingerprint } from "./types";
+import type { IdempotencyFingerprint } from "./brand";
 
 export type RequestIdentifier = {
   /**
@@ -35,24 +34,4 @@ export const isIdenticalRequest = (
     target.idempotencyKey === candidate.idempotencyKey &&
     target.fingerprint === candidate.fingerprint
   );
-};
-
-type CreateRequestIdentifierInput = {
-  idempotencyKey: string;
-  request: Request;
-};
-
-export const createRequestIdentifier = async (
-  spec: IdempotentRequestServerSpecification,
-  input: CreateRequestIdentifierInput,
-): Promise<RequestIdentifier> => {
-  const fingerprint = await spec.getFingerprint(input.request);
-  const requestPath = new URL(input.request.url).pathname;
-
-  return {
-    fingerprint,
-    idempotencyKey: input.idempotencyKey,
-    requestMethod: input.request.method,
-    requestPath,
-  };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,8 @@ export { IdempotencyKeyStorageError, UnsafeImplementationError } from "./error";
 
 export type { IdempotentRequest } from "./idempotent-request";
 
-export {
-  type IdempotentRequestImplementation,
-  idempotentRequestUniversalMiddleware,
-} from "./middleware";
+export { idempotentRequestUniversalMiddleware } from "./middleware";
+export type { IdempotentRequestImplementation } from "./middleware";
 
 export type { SerializedResponse } from "./serializer";
 export type { IdempotentRequestServerSpecification } from "./server/specification";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
+export { createIdempotencyFingerprint, createStorageKey } from "./brand";
+export type { IdempotencyFingerprint, StorageKey } from "./brand";
+
 export { IdempotencyKeyStorageError, UnsafeImplementationError } from "./error";
+
+export type { IdempotentRequest } from "./idempotent-request";
 
 export {
   type IdempotentRequestImplementation,
   idempotentRequestUniversalMiddleware,
 } from "./middleware";
 
-export {
-  createIdempotencyFingerprint,
-  createIdempotentStorageKey,
-  type IdempotencyFingerprint,
-  type IdempotentStorageKey,
-} from "./types";
-
-export type { SerializedResponse } from "./utils/response";
+export type { SerializedResponse } from "./serializer";
+export type { IdempotentRequestServerSpecification } from "./server/specification";
+export type { IdempotentRequestStorageDriver } from "./storage/driver";

--- a/src/serializer.test.ts
+++ b/src/serializer.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import type { SerializedResponse } from "./response";
+import type { SerializedResponse } from "./serializer";
 
-import { cloneAndSerializeResponse, deserializeResponse } from "./response";
+import { cloneAndSerializeResponse, deserializeResponse } from "./serializer";
 
 describe("serializeResponse", () => {
   it("can serialize a response", async () => {

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -16,7 +16,7 @@ export const cloneAndSerializeResponse = async (
   response: Response,
 ): Promise<SerializedResponse> => {
   const responseClone = response.clone();
-  // DO NOT REFERENCE ANY PROPERTIES OF THE ORIGINAL RESPONSE OR YOU WILL BE FIRED
+  // DO NOT REFERENCE ANY PROPERTIES OF THE ORIGINAL RESPONSE
 
   return {
     body: await responseClone.text(),

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createIdempotentRequestServer } from "./index";
+
+const stubSpecification = {
+  getFingerprint: vi.fn(),
+  getStorageKey: vi.fn(),
+  satisfiesKeySpec: vi.fn(),
+};
+
+describe("createIdempotentRequestServer", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const server = createIdempotentRequestServer(stubSpecification);
+
+  const mockIdempotencyKey = "8a6ead79-2c7c-4c83-a710-84cca2d645cc";
+  const mockRequest = new Request("http://localhost/user", {
+    body: JSON.stringify({
+      name: "John Doe",
+    }),
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": mockIdempotencyKey,
+    },
+    method: "POST",
+  });
+
+  describe("getRequestIdentifier", () => {
+    it("should return RequestIdentifier with fingerprint when getFingerprint returns a value", async () => {
+      stubSpecification.getFingerprint.mockResolvedValue("test-fingerprint");
+
+      const identifier = await server.getRequestIdentifier({
+        idempotencyKey: mockIdempotencyKey,
+        request: mockRequest,
+      });
+
+      expect(identifier).toStrictEqual({
+        fingerprint: "test-fingerprint",
+        idempotencyKey: mockIdempotencyKey,
+        requestMethod: "POST",
+        requestPath: "/user",
+      });
+    });
+
+    it("should return RequestIdentifier with null fingerprint when getFingerprint returns null", async () => {
+      stubSpecification.getFingerprint.mockResolvedValue(null);
+
+      const identifier = await server.getRequestIdentifier({
+        idempotencyKey: mockIdempotencyKey,
+        request: mockRequest,
+      });
+
+      expect(identifier).toStrictEqual({
+        fingerprint: null,
+        idempotencyKey: mockIdempotencyKey,
+        requestMethod: "POST",
+        requestPath: "/user",
+      });
+    });
+  });
+
+  describe("getStorageKey", () => {
+    it("should delegate to spec.getStorageKey", async () => {
+      const source = {
+        idempotencyKey: mockIdempotencyKey,
+        request: mockRequest,
+      };
+      stubSpecification.getStorageKey.mockResolvedValue("test-storage-key");
+
+      const storageKey = await server.getStorageKey(source);
+
+      expect(stubSpecification.getStorageKey).toHaveBeenCalledWith(source);
+      expect(storageKey).toStrictEqual("test-storage-key");
+    });
+  });
+
+  describe("satisfiesKeySpec", () => {
+    it("should delegate to spec.satisfiesKeySpec", () => {
+      stubSpecification.satisfiesKeySpec.mockReturnValue(true);
+
+      const result = server.satisfiesKeySpec(mockIdempotencyKey);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,54 @@
+import type { RequestIdentifier } from "../identifier";
+import type { IdempotentRequestServerSpecification } from "./specification";
+
+import {
+  createIdempotencyFingerprint,
+  createStorageKey,
+  type StorageKey,
+} from "../brand";
+
+export interface IdempotentRequestServer {
+  getRequestIdentifier(source: {
+    idempotencyKey: string;
+    request: Request;
+  }): Promise<RequestIdentifier>;
+
+  getStorageKey(source: {
+    idempotencyKey: string;
+    request: Request;
+  }): Promise<StorageKey>;
+
+  satisfiesKeySpec(idempotencyKey: string): boolean;
+}
+
+export const createIdempotentRequestServer = (
+  spec: IdempotentRequestServerSpecification,
+): IdempotentRequestServer => {
+  return {
+    async getStorageKey(source) {
+      const storageKey = await spec.getStorageKey(source);
+      return createStorageKey(storageKey);
+    },
+
+    async getRequestIdentifier({ idempotencyKey, request }) {
+      const requestPath = new URL(request.url).pathname;
+
+      const rawFingerprint = await spec.getFingerprint(request);
+      const fingerprint =
+        rawFingerprint == null
+          ? null
+          : createIdempotencyFingerprint(rawFingerprint);
+
+      return {
+        fingerprint,
+        idempotencyKey,
+        requestMethod: request.method,
+        requestPath,
+      };
+    },
+
+    satisfiesKeySpec(idempotencyKey) {
+      return spec.satisfiesKeySpec(idempotencyKey);
+    },
+  };
+};

--- a/src/server/specification.ts
+++ b/src/server/specification.ts
@@ -1,4 +1,3 @@
-import type { IdempotencyFingerprint, IdempotentStorageKey } from "../types";
 import type { MaybePromise } from "../utils/types";
 
 /**
@@ -20,7 +19,7 @@ export interface IdempotentRequestServerSpecification {
    * A fingerprint string representing the uniqueness of the request.
    * Returning `null` means this server specification does not use fingerprint.
    */
-  getFingerprint(request: Request): MaybePromise<IdempotencyFingerprint | null>;
+  getFingerprint(request: Request): MaybePromise<string | null>;
 
   /**
    * Get a key for searching the request in the storage.
@@ -34,12 +33,18 @@ export interface IdempotentRequestServerSpecification {
    *
    * @see {@link https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-06#section-5 Security Considerations}
    *
-   * @param request
+   * @param source
+   * @param source.idempotencyKey
+   * The `Idempotency-Key` header from the request
+   * @param source.request
    * Web-standard request object
    * @returns
    * A key that is used to retrieve the request from the storage.
    */
-  getStorageKey(request: Request): MaybePromise<IdempotentStorageKey>;
+  getStorageKey(source: {
+    idempotencyKey: string;
+    request: Request;
+  }): MaybePromise<string>;
 
   /**
    * Check if the idempotency key satisfies the server-defined specifications

--- a/src/server/specification.ts
+++ b/src/server/specification.ts
@@ -1,6 +1,20 @@
 import type { MaybePromise } from "../utils/types";
 
 /**
+ * Parameter object for getStorageKey method.
+ */
+interface GetStorageKeySource {
+  /**
+   * The `Idempotency-Key` header from the request
+   */
+  idempotencyKey: string;
+  /**
+   * Web-standard request object
+   */
+  request: Request;
+}
+
+/**
  * Specification - defines key validation and request digest generation.
  *
  * @see Section 2.2, 2.3, 2.4 of {@link https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-06#section-2}
@@ -34,17 +48,11 @@ export interface IdempotentRequestServerSpecification {
    * @see {@link https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-06#section-5 Security Considerations}
    *
    * @param source
-   * @param source.idempotencyKey
-   * The `Idempotency-Key` header from the request
-   * @param source.request
-   * Web-standard request object
+   * Object containing idempotencyKey and request
    * @returns
    * A key that is used to retrieve the request from the storage.
    */
-  getStorageKey(source: {
-    idempotencyKey: string;
-    request: Request;
-  }): MaybePromise<string>;
+  getStorageKey(source: GetStorageKeySource): MaybePromise<string>;
 
   /**
    * Check if the idempotency key satisfies the server-defined specifications

--- a/src/storage/driver.ts
+++ b/src/storage/driver.ts
@@ -1,0 +1,28 @@
+import type { StorageKey } from "../brand";
+import type { IdempotentRequest } from "../idempotent-request";
+import type { MaybePromise } from "../utils/types";
+
+/**
+ * Storage for idempotent request records.
+ *
+ * You should implement features like TTL, cleanup, etc. at this layer.
+ */
+export interface IdempotentRequestStorageDriver {
+  /**
+   * Get a stored request.
+   *
+   * @param storageKey
+   * The storage key of the request.
+   * @returns
+   * Stored request or `null` if the request is not found.
+   */
+  get(storageKey: StorageKey): MaybePromise<IdempotentRequest | null>;
+
+  /**
+   * Save a request.
+   *
+   * @param request
+   * The request to save.
+   */
+  save(request: IdempotentRequest): MaybePromise<void>;
+}

--- a/src/storage/index.test.ts
+++ b/src/storage/index.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ProcessedIdempotentRequest,
+  ProcessingIdempotentRequest,
+  UnProcessedIdempotentRequest,
+} from "../idempotent-request";
+import type { SerializedResponse } from "../serializer";
+
+import { createStorageKey } from "../brand";
+import { IdempotencyKeyStorageError } from "../error";
+import { createIdempotentRequestStorage } from "./index";
+
+const fakeDriver = {
+  get: vi.fn(),
+  save: vi.fn(),
+};
+
+describe("createIdempotentRequestStorage", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:01:00.000Z")); // Consistent lockedAt
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const storage = createIdempotentRequestStorage(fakeDriver);
+
+  const baseRequest: UnProcessedIdempotentRequest = {
+    fingerprint: null,
+    idempotencyKey: "cd4e21a0-f506-4ca3-a825-522a28bf7165",
+    lockedAt: null,
+    requestMethod: "POST",
+    requestPath: "/test",
+    response: null,
+    storageKey: createStorageKey("test-key"),
+  };
+
+  describe("acquireLock", () => {
+    it("should acquire a lock and save the processing request", async () => {
+      const lockedRequest = await storage.acquireLock(baseRequest);
+
+      expect(lockedRequest).toStrictEqual({
+        ...baseRequest,
+        lockedAt: new Date("2024-01-01T00:01:00.000Z"),
+      });
+    });
+
+    it("should throw IdempotencyKeyStorageError if driver.save fails", async () => {
+      const driverError = new Error("Driver save failed");
+      fakeDriver.save.mockRejectedValue(driverError);
+
+      await expect(storage.acquireLock(baseRequest)).rejects.toThrowError(
+        new IdempotencyKeyStorageError(
+          `Failed to acquire a lock for the stored idempotent request: ${baseRequest.storageKey}`,
+          { cause: driverError },
+        ),
+      );
+      expect(fakeDriver.save).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("findOrCreate", () => {
+    const response: SerializedResponse = {
+      body: '{"id": 123}',
+      headers: { location: "/new-resource" },
+      status: 201,
+    };
+
+    it("should early return with cached request if already processed", async () => {
+      const existingRequest: ProcessedIdempotentRequest = {
+        ...baseRequest,
+        response,
+      };
+      fakeDriver.get.mockResolvedValue(existingRequest);
+
+      const result = await storage.findOrCreate(baseRequest);
+
+      expect(result).toStrictEqual({
+        created: false,
+        request: existingRequest,
+      });
+      expect(fakeDriver.save).not.toHaveBeenCalled();
+    });
+
+    it("should create and save a new unprocessed request if not found", async () => {
+      const expectedNewRequest: UnProcessedIdempotentRequest = {
+        ...baseRequest,
+        lockedAt: null,
+        response: null,
+      };
+      fakeDriver.get.mockResolvedValue(null);
+
+      const result = await storage.findOrCreate(baseRequest);
+
+      expect(result).toStrictEqual({
+        created: true,
+        request: expectedNewRequest,
+      });
+    });
+
+    it("should throw IdempotencyKeyStorageError if driver.get fails", async () => {
+      const driverError = new Error("Driver get failed");
+      fakeDriver.get.mockRejectedValue(driverError);
+
+      await expect(storage.findOrCreate(baseRequest)).rejects.toThrowError(
+        new IdempotencyKeyStorageError(
+          `Failed to find or create the stored idempotent request: ${baseRequest.storageKey}`,
+          { cause: driverError },
+        ),
+      );
+    });
+
+    it("should throw IdempotencyKeyStorageError if driver.save fails", async () => {
+      const driverError = new Error("Driver save failed");
+      fakeDriver.save.mockRejectedValue(driverError);
+
+      await expect(storage.findOrCreate(baseRequest)).rejects.toThrowError(
+        new IdempotencyKeyStorageError(
+          `Failed to find or create the stored idempotent request: ${baseRequest.storageKey}`,
+          { cause: driverError },
+        ),
+      );
+    });
+  });
+
+  describe("setResponseAndUnlock", () => {
+    const processingRequest: ProcessingIdempotentRequest = {
+      ...baseRequest,
+      lockedAt: new Date("2024-01-01T00:01:00.000Z"),
+      response: null,
+    };
+
+    const response: SerializedResponse = {
+      body: '{"id": 123}',
+      headers: { location: "/new-resource" },
+      status: 201,
+    };
+
+    it("should set the response, unlock the request, and save", async () => {
+      await storage.setResponseAndUnlock(processingRequest, response);
+
+      expect(fakeDriver.save).toHaveBeenCalledExactlyOnceWith({
+        ...processingRequest,
+        lockedAt: null,
+        response,
+      });
+    });
+
+    it("should throw IdempotencyKeyStorageError if driver.save fails", async () => {
+      const driverError = new Error("Driver save failed");
+      fakeDriver.save.mockRejectedValue(driverError);
+
+      await expect(
+        storage.setResponseAndUnlock(processingRequest, response),
+      ).rejects.toThrowError(
+        new IdempotencyKeyStorageError(
+          `Failed to save the response of an idempotent request: ${processingRequest.storageKey}. You should unlock the request manually.`,
+          { cause: driverError },
+        ),
+      );
+      expect(fakeDriver.save).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
- Separate `IdempotentRequestStorage` and `IdempotentRequestStorageDriver`
  - Users should implement `IdempotentRequestStorageDriver`
- Separate `IdempotentRequestServer` and `IdempotentRequestServerSpecification`
  - Users should implement `IdempotentRequestServerSpecification`